### PR TITLE
Separate HCL syntax into its own file

### DIFF
--- a/Terraform-hcl.sublime-settings
+++ b/Terraform-hcl.sublime-settings
@@ -1,0 +1,4 @@
+{
+	"tab_size": 2,
+	"translate_tabs_to_spaces": true
+}

--- a/Terraform-hcl.sublime-syntax
+++ b/Terraform-hcl.sublime-syntax
@@ -1,0 +1,28 @@
+%YAML 1.2
+#
+# This syntax definition is based on the Terraform guide:
+# https://www.terraform.io/docs/configuration/index.html
+#
+# As well as the HCL Native Syntax Spec:
+# https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md
+#
+# For documentation on the .subline-syntax format:
+# https://www.sublimetext.com/docs/syntax.html
+#
+# Regex's in this file support the Oniguruma regex engine:
+# https://raw.githubusercontent.com/kkos/oniguruma/5.9.6/doc/RE
+#
+---
+name: Terraform (HCL)
+
+# File Extensions:
+#
+# - ".hcl": non-terraform tools often use this HCL syntax, i.e. Vault
+#   https://www.vaultproject.io/docs/configuration/
+file_extensions:
+  - hcl
+scope: source.terraform-hcl
+
+contexts:
+  main:
+    - include: scope:source.terraform

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -19,12 +19,8 @@ name: Terraform
 #
 # - ".tf": the standard file extension
 #   https://www.terraform.io/docs/language/index.html
-#
-# - ".hcl": non-terraform tools often use this HCL syntax, i.e. Vault
-#   https://www.vaultproject.io/docs/configuration/
 file_extensions:
   - tf
-  - hcl
 scope: source.terraform
 
 variables:


### PR DESCRIPTION
Per discussions in https://github.com/sublimelsp/LSP-terraform/issues/26 and in https://github.com/alexlouden/Terraform.tmLanguage/issues/48 I've extracted support for `.hcl` files into a dedicated syntax that inherits the main syntax.

The point of it is to make `.hcl` extension not be handled by the main syntax so that it doesn't get the same `source.terraform` scope but a dedicated `source.terraform-hcl` scope. This is required for Sublime LSP as it enables language server based on the scope and it isn't possible to exclude `.hcl` from starting the server otherwise.

tm-language syntax is unaffected.

Resolves https://github.com/sublimelsp/LSP-terraform/issues/26
Resolves https://github.com/alexlouden/Terraform.tmLanguage/issues/48

@radeksimko